### PR TITLE
Jpuerto/nihdev 401 reduce initial startup

### DIFF
--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -89,7 +89,7 @@ class JupyterLabJob(AbstractJob):
         return {
             "metrics": {
                 "time_init": time_init,
-                "timestamp_init": time.mktime(timestamp_init),
+                "timestamp_init": time.mktime(timestamp_init.timetuple()),
             },
             "current_job_details": {
                 "message": "Webserver ready.",

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -77,7 +77,10 @@ class JupyterLabJob(AbstractJob):
 
         connection_string = f"{url.path}?token={token}"
 
-        time_init = datetime.now() - job_model.datetime_start
+        time_init = (
+            datetime.now(job_model.datetime_start.tzinfo) - job_model.datetime_start
+        )
+
         time_init = (
             time_init.total_seconds() / 3600 if time_init.total_seconds() != 0 else 0
         )

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -83,9 +83,7 @@ class JupyterLabJob(AbstractJob):
         )
 
         return {
-            "metrics": {
-                "time_init": time_init
-            },
+            "metrics": {"time_init": time_init},
             "current_job_details": {
                 "message": "Webserver ready.",
                 "proxy_details": {

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -80,15 +80,11 @@ class JupyterLabJob(AbstractJob):
 
         time_init = (
             datetime.now(job_model.datetime_start.tzinfo) - job_model.datetime_start
-        )
-
-        time_init = (
-            time_init.total_seconds() / 3600 if time_init.total_seconds() != 0 else 0
-        )
+        ).total_seconds()
 
         return {
             "metrics": {
-                "time_init": time_init,
+                "time_init": time_init / 3600 if time_init != 0 else 0,
             },
             "current_job_details": {
                 "message": "Webserver ready.",

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -83,7 +83,9 @@ class JupyterLabJob(AbstractJob):
         )
 
         return {
-            "metrics": {"time_init": time_init},
+            "metrics": {
+                "time_init": time_init
+            },
             "current_job_details": {
                 "message": "Webserver ready.",
                 "proxy_details": {

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from urllib import parse
 
 from django.apps import apps
@@ -76,14 +77,24 @@ class JupyterLabJob(AbstractJob):
 
         connection_string = f"{url.path}?token={token}"
 
+        time_init = datetime.now() - job_model.datetime_start
+        time_init = (
+            time_init.total_seconds() / 3600 if time_init.total_seconds() != 0 else 0
+        )
+
         return {
-            "message": "Webserver ready.",
-            "proxy_details": {
-                "hostname": hostname,
-                "port": port,
-                "path": connection_string,
+            "metrics": {
+                "time_init": time_init
             },
-            "connection_details": {
-                "url_path": connection_string,
+            "current_job_details": {
+                "message": "Webserver ready.",
+                "proxy_details": {
+                    "hostname": hostname,
+                    "port": port,
+                    "path": connection_string,
+                },
+                "connection_details": {
+                    "url_path": connection_string,
+                },
             },
         }

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -78,9 +78,9 @@ class JupyterLabJob(AbstractJob):
 
         connection_string = f"{url.path}?token={token}"
 
-        timestamp_init = datetime.now(job_model.datetime_start.tzinfo)
-
-        time_init = timestamp_init - job_model.datetime_start
+        time_init = (
+            datetime.now(job_model.datetime_start.tzinfo) - job_model.datetime_start
+        )
 
         time_init = (
             time_init.total_seconds() / 3600 if time_init.total_seconds() != 0 else 0
@@ -89,7 +89,6 @@ class JupyterLabJob(AbstractJob):
         return {
             "metrics": {
                 "time_init": time_init,
-                "timestamp_init": time.mktime(timestamp_init.timetuple()),
             },
             "current_job_details": {
                 "message": "Webserver ready.",

--- a/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
+++ b/src/user_workspaces_server/controllers/jobtypes/jupyter_lab_job.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import time
 from datetime import datetime
 from urllib import parse
 

--- a/src/user_workspaces_server/tasks.py
+++ b/src/user_workspaces_server/tasks.py
@@ -33,7 +33,7 @@ def update_job_status(job_id):
     job.refresh_from_db()
 
     if current_job_status == models.Job.Status.RUNNING and job.datetime_start is None:
-        job.datetime_start = datetime.datetime.now()
+        job.datetime_start = datetime.datetime.now(job.datetime_created.tzinfo)
         time_pending = (job.datetime_start - job.datetime_created).total_seconds()
         job.job_details["metrics"]["time_pending"] = (
             time_pending / 3600 if time_pending != 0 else 0

--- a/src/user_workspaces_server/tasks.py
+++ b/src/user_workspaces_server/tasks.py
@@ -71,8 +71,10 @@ def update_job_status(job_id):
     # TODO: Make sure that we're using the resource to do this type of status check
     job_status = job_type.status_check(job)
 
-    job.job_details["current_job_details"].update(job_status["current_job_details"])
-    job.job_details["metrics"].update(job_status["metrics"])
+    job.job_details["current_job_details"].update(
+        job_status.get("current_job_details", {})
+    )
+    job.job_details["metrics"].update(job_status.get("metrics", {}))
 
     # TODO: At some point we will have metrics returned by resource_job_info
     job.job_details["current_job_details"].update(

--- a/src/user_workspaces_server/tasks.py
+++ b/src/user_workspaces_server/tasks.py
@@ -69,11 +69,12 @@ def update_job_status(job_id):
         raise Exception("Invalid job type specified")
 
     # TODO: Make sure that we're using the resource to do this type of status check
-    job.job_details["current_job_details"].update(job_type.status_check(job))
+    job_status = job_type.status_check(job)
 
-    # TODO: Grab the current_job_details from resource_job_info and update the job.job_details["current_job_details"] with it.
+    job.job_details["current_job_details"].update(job_status["current_job_details"])
+    job.job_details["metrics"].update(job_status["metrics"])
 
-    # job.job_details["current_job_details"].update(resource_job_info["current_job_details"])
+    # TODO: At some point we will have metrics returned by resource_job_info
     job.job_details["current_job_details"].update(
         resource_job_info["current_job_details"]
     )

--- a/src/user_workspaces_server/tasks.py
+++ b/src/user_workspaces_server/tasks.py
@@ -34,6 +34,10 @@ def update_job_status(job_id):
 
     if current_job_status == models.Job.Status.RUNNING and job.datetime_start is None:
         job.datetime_start = datetime.datetime.now()
+        time_pending = (job.datetime_start - job.datetime_created).total_seconds()
+        job.job_details["metrics"]["time_pending"] = (
+            time_pending / 3600 if time_pending != 0 else 0
+        )
     elif current_job_status in [models.Job.Status.COMPLETE, models.Job.Status.FAILED]:
         job.datetime_end = datetime.datetime.now()
 

--- a/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
+++ b/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
@@ -2,22 +2,27 @@
 VENV_PATH="{{ workspace_full_path }}/JupyterLabJob_venv"
 
 ### Environment initialization
-{% if module_manager == "lmod" %}
-module load {{ modules|join:" " }}
-{% if use_local_environment %}
-if [ ! -d "$VENV_PATH" ]; then
-  export PYTHONNOUSERSITE=True
-  conda create --prefix "$VENV_PATH" python={{ python_version }} -y
-fi
-source activate "$VENV_PATH"
-pip install {{ python_packages|join:" " }}
+{% if module_manager == "tar" %}
+  mkdir -p "$VENV_PATH"
+  tar -xzf {{ tar_file_path }} -C "$VENV_PATH"
+  source "$VENV_PATH/bin/activate"
 {% endif %}
+{% if module_manager == "lmod" %}
+  module load {{ modules|join:" " }}
+  {% if use_local_environment %}
+    if [ ! -d "$VENV_PATH" ]; then
+      export PYTHONNOUSERSITE=True
+      conda create --prefix "$VENV_PATH" python={{ python_version }} -y
+    fi
+    source activate "$VENV_PATH"
+    pip install {{ python_packages|join:" " }}
+  {% endif %}
 {% elif module_manager == "virtualenv" %}
-if [ ! -d "$VENV_PATH" ]; then
-  virtualenv -p {{ python_version }} "$VENV_PATH"
-fi
-source "$VENV_PATH/bin/activate"
-pip install {{ python_packages|join:" " }}
+  if [ ! -d "$VENV_PATH" ]; then
+    virtualenv -p {{ python_version }} "$VENV_PATH"
+  fi
+  source "$VENV_PATH/bin/activate"
+  pip install {{ python_packages|join:" " }}
 {% endif %}
 
 ### Jupyter configuration

--- a/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
+++ b/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
@@ -6,6 +6,7 @@ VENV_PATH="{{ workspace_full_path }}/JupyterLabJob_venv"
   mkdir -p "$VENV_PATH"
   tar -xzf {{ tar_file_path }} -C "$VENV_PATH"
   source "$VENV_PATH/bin/activate"
+  pip install {{ python_packages|join:" " }}
 {% endif %}
 {% if module_manager == "lmod" %}
   module load {{ modules|join:" " }}

--- a/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
+++ b/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
@@ -3,10 +3,11 @@ VENV_PATH="{{ workspace_full_path }}/.JupyterLabJob_venv"
 
 ### Environment initialization
 {% if module_manager == "tar" %}
-  mkdir -p "$VENV_PATH"
-  tar -xzf {{ tar_file_path }} -C "$VENV_PATH"
+  if [ ! -d "$VENV_PATH" ]; then
+    mkdir -p "$VENV_PATH"
+    tar -xzf {{ tar_file_path }} -C "$VENV_PATH"
+  fi
   source "$VENV_PATH/bin/activate"
-  pip install {{ python_packages|join:" " }}
 {% endif %}
 {% if module_manager == "lmod" %}
   module load {{ modules|join:" " }}

--- a/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
+++ b/src/user_workspaces_server/templates/script_templates/jupyter_lab_template.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VENV_PATH="{{ workspace_full_path }}/JupyterLabJob_venv"
+VENV_PATH="{{ workspace_full_path }}/.JupyterLabJob_venv"
 
 ### Environment initialization
 {% if module_manager == "tar" %}

--- a/src/user_workspaces_server/views/workspace_view.py
+++ b/src/user_workspaces_server/views/workspace_view.py
@@ -217,6 +217,7 @@ class WorkspaceView(APIView):
                 "job_type": body["job_type"],
                 "datetime_created": datetime.now(),
                 "job_details": {
+                    "metrics": {},
                     "request_job_details": job_details,
                     "current_job_details": {},
                 },

--- a/src/user_workspaces_server/views/workspace_view.py
+++ b/src/user_workspaces_server/views/workspace_view.py
@@ -53,13 +53,13 @@ class WorkspaceView(APIView):
 
         workspace_details = body.get("workspace_details", {})
 
+        if not isinstance(workspace_details, dict):
+            raise ParseError("Workspace details not JSON.")
+
         request_workspace_details = {
             "files": [file["name"] for file in workspace_details.get("files", [])],
             "symlinks": workspace_details.get("symlinks", []),
         }
-
-        if not isinstance(workspace_details, dict):
-            raise ParseError("Workspace details not JSON.")
 
         workspace_data = {
             "user_id": request.user,

--- a/src/user_workspaces_server/views/workspace_view.py
+++ b/src/user_workspaces_server/views/workspace_view.py
@@ -53,6 +53,11 @@ class WorkspaceView(APIView):
 
         workspace_details = body.get("workspace_details", {})
 
+        request_workspace_details = {
+            "files": [file["name"] for file in workspace_details.get("files", [])],
+            "symlinks": workspace_details.get("symlinks", []),
+        }
+
         if not isinstance(workspace_details, dict):
             raise ParseError("Workspace details not JSON.")
 
@@ -63,7 +68,7 @@ class WorkspaceView(APIView):
             "disk_space": 0,
             "datetime_created": datetime.now(),
             "workspace_details": {
-                "request_workspace_details": workspace_details,
+                "request_workspace_details": request_workspace_details,
                 "current_workspace_details": {"files": [], "symlinks": []},
             },
             "status": "idle",


### PR DESCRIPTION
This PR includes:

- New "tar" module_manager that will be used to decrease initial load times.
- New "metrics" sub-dictionary. This currently lives on "job_details" and will include information
  - time_init - this is the amount of time it takes to "start" a job once it has been allocated. IE, how long until the JupyterLab webserver is available
  - time_pending - this is the amount of time that a particular job is sitting in the resource queue